### PR TITLE
Fixed Initialization of image buffers

### DIFF
--- a/vx_loomsl/kernels/chroma_key.h
+++ b/vx_loomsl/kernels/chroma_key.h
@@ -28,7 +28,6 @@ THE SOFTWARE.
 
 //////////////////////////////////////////////////////////////////////
 //! \brief The Chroma Key kernel registration functions.
-vx_status chroma_key_merge_publish(vx_context context);
 vx_status chroma_key_mask_generation_publish(vx_context context);
 
 #endif //__CHROMA_KEY_H__

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -1489,22 +1489,6 @@ static vx_status InitializeInternalTablesForCamera(ls_context stitch)
 			_mm_store_si128(dst++, r0);
 		}
 		ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->warp_output_image, map_id));
-		if (stitch->exp_comp_output_image) {
-			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->exp_comp_output_image, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
-			__m128i *dst = (__m128i*) ptr;
-			vx_size size_in_bytes = (addr.stride_y * addr.dim_y)&~127;
-			for (vx_uint32 i = 0; i < size_in_bytes; i += 128){
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-			}
-			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->exp_comp_output_image, map_id));
-		}
 		if (stitch->expcomp_luma16) {
 			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->expcomp_luma16, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
 			__m128i *dst = (__m128i*) ptr;

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -1521,11 +1521,11 @@ static vx_status InitializeInternalTablesForCamera(ls_context stitch)
 			}
 			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->expcomp_luma16, map_id));
 		}	
-		// initialize overlay_rgb or output_rgb to 0:
+		// initialize merge output
 		r0 = _mm_set1_epi32(0x00000000);
 		rect = { 0, 0, eqrWidth, eqrHeight };
-		if (stitch->Img_overlay_rgb){
-			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->Img_overlay_rgb, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
+		if (stitch->rgb_output){
+			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->rgb_output, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
 			__m128i *dst = (__m128i*) ptr;
 			vx_size size_in_bytes = (addr.stride_y * addr.dim_y)&~127;
 			for (vx_uint32 i = 0; i < size_in_bytes; i += 128){
@@ -1538,23 +1538,7 @@ static vx_status InitializeInternalTablesForCamera(ls_context stitch)
 				_mm_store_si128(dst++, r0);
 				_mm_store_si128(dst++, r0);
 			}
-			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->Img_overlay_rgb, map_id));
-		}
-		else if (stitch->Img_output_rgb){
-			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->Img_output_rgb, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
-			__m128i *dst = (__m128i*) ptr;
-			vx_size size_in_bytes = (addr.stride_y * addr.dim_y)&~127;
-			for (vx_uint32 i = 0; i < size_in_bytes; i += 128){
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-				_mm_store_si128(dst++, r0);
-			}
-			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->Img_output_rgb, map_id));
+			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->rgb_output, map_id));
 		}
 	}
 	return VX_SUCCESS;

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -597,7 +597,6 @@ static const char * GetFileNameSuffix(ls_context stitch, vx_reference ref, bool&
 		{ (vx_reference)stitch->valid_array,           false, false, "exp-valid.bin" },
 		{ (vx_reference)stitch->OverlapPixelEntry,     false, false, "exp-overlap.bin" },
 		{ (vx_reference)stitch->overlap_matrix,        false, true,  "exp-count.bin" },
-		{ (vx_reference)stitch->exp_comp_output_image, false, false, "exp-rgby.raw" },
 		{ (vx_reference)stitch->valid_mask_image,      false, false, "valid-mask.raw" },
 		{ (vx_reference)stitch->seamfind_valid_array,  false, false, "seam-valid.bin" },
 		{ (vx_reference)stitch->seamfind_weight_array, false, false, "seam-weight.bin" },
@@ -1668,10 +1667,10 @@ static vx_status AllocateInternalTablesForCamera(ls_context stitch)
 		}
 		ERROR_CHECK_OBJECT_(stitch->overlap_matrix = vxCreateMatrix(stitch->context, VX_TYPE_INT32, stitch->num_cameras, stitch->num_cameras));
 		if (stitch->live_stitch_attr[LIVE_STITCH_ATTR_PRECISION] == 2){
-			ERROR_CHECK_OBJECT_(stitch->exp_comp_output_image = vxCreateImage(stitch->context, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height * stitch->num_cameras, VX_DF_IMAGE_RGB4_AMD));
+			ERROR_CHECK_OBJECT_(stitch->exp_comp_output_image = vxCreateVirtualImage(stitch->graphStitch, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height * stitch->num_cameras, VX_DF_IMAGE_RGB4_AMD));
 		}
 		else{
-			ERROR_CHECK_OBJECT_(stitch->exp_comp_output_image = vxCreateImage(stitch->context, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height * stitch->num_cameras, VX_DF_IMAGE_RGBX));
+			ERROR_CHECK_OBJECT_(stitch->exp_comp_output_image = vxCreateVirtualImage(stitch->graphStitch, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height * stitch->num_cameras, VX_DF_IMAGE_RGBX));
 		}
 		if (stitch->EXPO_COMP == 1) {
 			ERROR_CHECK_OBJECT_(stitch->A_matrix = vxCreateMatrix(stitch->context, VX_TYPE_INT32, stitch->num_cameras, stitch->num_cameras));

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -720,7 +720,6 @@ static vx_status SyncInternalTables(ls_context stitch)
 		(vx_reference)stitch->seamfind_scene_array,
 		(vx_reference)stitch->blend_mask_image,
 		(vx_reference)stitch->warp_output_image,
-		(vx_reference)stitch->rgb_output,
 		(vx_reference)stitch->overlay_remap,
 		(vx_reference)stitch->camera_remap,
 	};

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -1496,7 +1496,6 @@ static vx_status InitializeInternalTablesForCamera(ls_context stitch)
 		}
 
 		// initialize merge output
-		r0 = _mm_set1_epi32(0x00000000);
 		rect = { 0, 0, eqrWidth, eqrHeight };
 		if (stitch->rgb_output){
 			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->rgb_output, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -1523,6 +1523,7 @@ static vx_status InitializeInternalTablesForCamera(ls_context stitch)
 		}	
 		// initialize overlay_rgb or output_rgb to 0:
 		r0 = _mm_set1_epi32(0x00000000);
+		rect = { 0, 0, eqrWidth, eqrHeight };
 		if (stitch->Img_overlay_rgb){
 			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->Img_overlay_rgb, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
 			__m128i *dst = (__m128i*) ptr;

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -2468,10 +2468,10 @@ LIVE_STITCH_API_ENTRY vx_status VX_API_CALL lsInitialize(ls_context stitch)
 		// create remap table object and image for overlay warp
 		ERROR_CHECK_OBJECT_(stitch->overlay_remap = vxCreateRemap(stitch->context, stitch->overlay_buffer_width, stitch->overlay_buffer_height, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height));
 		if (stitch->live_stitch_attr[LIVE_STITCH_ATTR_PRECISION] == 2){
-			ERROR_CHECK_OBJECT_(stitch->Img_overlay_rgb = vxCreateVirtualImage(stitch->graphStitch, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height, VX_DF_IMAGE_RGB4_AMD));
+			ERROR_CHECK_OBJECT_(stitch->Img_overlay_rgb = vxCreateImage(stitch->context, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height, VX_DF_IMAGE_RGB4_AMD));
 		}
 		else{ //8bit mode
-			ERROR_CHECK_OBJECT_(stitch->Img_overlay_rgb = vxCreateVirtualImage(stitch->graphStitch, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height, VX_DF_IMAGE_RGB));
+			ERROR_CHECK_OBJECT_(stitch->Img_overlay_rgb = vxCreateImage(stitch->context, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height, VX_DF_IMAGE_RGB));
 		}
 		ERROR_CHECK_OBJECT_(stitch->Img_overlay_rgba = vxCreateVirtualImage(stitch->graphStitch, stitch->output_rgb_buffer_width, stitch->output_rgb_buffer_height, VX_DF_IMAGE_RGBX));
 		// initialize remap using lens model

--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -1519,10 +1519,42 @@ static vx_status InitializeInternalTablesForCamera(ls_context stitch)
 				_mm_store_si128(dst++, r0);
 				_mm_store_si128(dst++, r0);
 			}
-			//			for (vx_uint32 i = 0; i < (addr.stride_y * addr.dim_y) / 4; i++)
-			//				ptr[i] = 0x80000000;
 			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->expcomp_luma16, map_id));
-		}		
+		}	
+		// initialize overlay_rgb or output_rgb to 0:
+		r0 = _mm_set1_epi32(0x00000000);
+		if (stitch->Img_overlay_rgb){
+			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->Img_overlay_rgb, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
+			__m128i *dst = (__m128i*) ptr;
+			vx_size size_in_bytes = (addr.stride_y * addr.dim_y)&~127;
+			for (vx_uint32 i = 0; i < size_in_bytes; i += 128){
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+			}
+			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->Img_overlay_rgb, map_id));
+		}
+		else if (stitch->Img_output_rgb){
+			ERROR_CHECK_STATUS_(vxMapImagePatch(stitch->Img_output_rgb, &rect, 0, &map_id, &addr, (void **)&ptr, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, VX_NOGAP_X));
+			__m128i *dst = (__m128i*) ptr;
+			vx_size size_in_bytes = (addr.stride_y * addr.dim_y)&~127;
+			for (vx_uint32 i = 0; i < size_in_bytes; i += 128){
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+				_mm_store_si128(dst++, r0);
+			}
+			ERROR_CHECK_STATUS_(vxUnmapImagePatch(stitch->Img_output_rgb, map_id));
+		}
 	}
 	return VX_SUCCESS;
 }


### PR DESCRIPTION
LiveStitch:

- Fixed artifacts in output image when using overlay: Merge output had been created as virtual images, but since the kernel will not write in all pixels, it needs to be a normal image and it needs to be initialized to zero.
- Created function for initialize buffers to a certain value
- Removed initialization for ExpComp since it is not needed